### PR TITLE
feat: add Slack event logging middleware for issue #1

### DIFF
--- a/backend/ingestion-service/cmd/main.go
+++ b/backend/ingestion-service/cmd/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/digital-memory/ingestion-service/internal/handlers"
 	"github.com/digital-memory/ingestion-service/internal/middleware"
 	"github.com/digital-memory/ingestion-service/internal/queue"
+        
 )
 
 func init() {
@@ -68,6 +69,7 @@ func main() {
 	router.Use(middleware.LoggingMiddleware(logger))
 	router.Use(middleware.ErrorHandlingMiddleware())
 	router.Use(middleware.RateLimitMiddleware())
+        router.Use(middleware.SlackLoggerMiddleware(logger))
 
 	// Initialize handler and register routes
 	handlerService := handlers.NewEventHandler(db, redisProducer, logger)

--- a/backend/ingestion-service/internal/middleware/slack_logger.go
+++ b/backend/ingestion-service/internal/middleware/slack_logger.go
@@ -1,0 +1,71 @@
+package middleware
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+)
+
+// SlackLoggerMiddleware logs all incoming Slack webhook requests
+func SlackLoggerMiddleware(logger *zap.Logger) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Only log Slack webhook endpoints
+		if c.Request.URL.Path != "/webhook/slack" {
+			c.Next()
+			return
+		}
+
+		start := time.Now()
+
+		// Read the request body
+		body, err := io.ReadAll(c.Request.Body)
+		if err != nil {
+			logger.Error("Failed to read request body", zap.Error(err))
+			c.Next()
+			return
+		}
+
+		// Restore the body so the handler can read it
+		c.Request.Body = io.NopCloser(bytes.NewReader(body))
+
+		// Parse as JSON for structured logging
+		var slackEvent map[string]interface{}
+		if err := json.Unmarshal(body, &slackEvent); err == nil {
+			// Log with structured fields
+			logger.Info("Slack webhook received",
+				zap.String("event_type", getString(slackEvent, "type")),
+				zap.String("team_id", getString(slackEvent, "team_id")),
+				zap.String("event_id", getString(slackEvent, "event_id")),
+				zap.Int64("event_time", getInt64(slackEvent, "event_time")),
+				zap.Duration("latency", time.Since(start)),
+			)
+		} else {
+			// Fallback: log raw body
+			logger.Info("Slack webhook received",
+				zap.String("raw_body", string(body)),
+				zap.Duration("latency", time.Since(start)),
+			)
+		}
+
+		c.Next()
+	}
+}
+
+// Helper functions
+func getString(m map[string]interface{}, key string) string {
+	if val, ok := m[key].(string); ok {
+		return val
+	}
+	return ""
+}
+
+func getInt64(m map[string]interface{}, key string) int64 {
+	if val, ok := m[key].(float64); ok {
+		return int64(val)
+	}
+	return 0
+}


### PR DESCRIPTION
## What this PR does
Adds SlackLoggerMiddleware that logs all incoming Slack webhook requests with structured JSON logging.

## Changes
- New file: `internal/middleware/slack_logger.go`
- Modified: `cmd/main.go` (added middleware to router)

## How to test
```bash
curl -X POST http://localhost:8001/webhook/slack -H "Content-Type: application/json" -d "{\"type\":\"test\",\"team_id\":\"T123\"}"
docker-compose logs ingestion-service --tail=10

##Why "invalid signature" appears
My middleware logs the request before signature check 

Existing handler rejects it due to missing real Slack signature 

This is expected, not a bug. The logs prove my middleware works.

Demo Link - https://github.com/user-attachments/assets/e603fb9f-cf5c-44a7-bbc0-d7cca40ff737

<img width="1913" height="698" alt="image" src="https://github.com/user-attachments/assets/ed7dad30-081b-42cf-92d4-662ff113d967" />


