### PR TITLE
fix: add payload size limit

### DIFF
--- a/backend/api-service/cmd/main.go
+++ b/backend/api-service/cmd/main.go
@@ -61,6 +61,7 @@ func main() {
 	router.Use(middleware.LoggingMiddleware(logger))
 	router.Use(middleware.ErrorHandlingMiddleware())
 	router.Use(middleware.RateLimitMiddleware())
+	router.Use(middleware.PayloadLimitMiddleware(1 << 20)) // 1MB limit
 
 	// Initialize handlers
 	handlerService := handlers.NewQueryHandler(db, vectorDB, logger)

--- a/backend/api-service/internal/middleware/middleware.go
+++ b/backend/api-service/internal/middleware/middleware.go
@@ -47,3 +47,11 @@ func RateLimitMiddleware() gin.HandlerFunc {
 		c.Next()
 	}
 }
+
+// PayloadLimitMiddleware limits the size of request bodies
+func PayloadLimitMiddleware(maxBytes int64) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxBytes)
+		c.Next()
+	}
+}


### PR DESCRIPTION
This PR fixes critical stability and security vulnerabilities identified in the NSoC level 3 audit assignment. Added payload size limits to prevent DoS attacks. Fixes #24